### PR TITLE
Enable PR linting with Danger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "no-console": ["off"],
     "prefer-template": ["off"],
     "semi": ["error", "never"],
-    "react/require-extension": "off",
+    "react/require-extension": "off"
   },
   "env": { "jest": true, "node": true, "browser": true, "jasmine": true }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   global:
   - secure: TODO
 before_script:
-- npm run lint | tee /tmp/eslint.out
 - npm run danger ci
 - psql -c 'CREATE DATABASE spoke_test;' -U postgres
 - psql -c "CREATE USER spoke_test WITH PASSWORD 'spoke_test';" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
   - secure: TODO
 before_script:
+- npm run lint | tee /tmp/eslint.out
 - npm run danger ci
 - psql -c 'CREATE DATABASE spoke_test;' -U postgres
 - psql -c "CREATE USER spoke_test WITH PASSWORD 'spoke_test';" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
   - secure: TODO
 before_script:
+- npm run danger ci
 - psql -c 'CREATE DATABASE spoke_test;' -U postgres
 - psql -c "CREATE USER spoke_test WITH PASSWORD 'spoke_test';" -U postgres
 - psql -c 'GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;' -U postgres

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -9,9 +9,13 @@ const lintReport = linter.executeOnFiles([...modified, ...created])
 
 const { warningCount, errorCount } = lintReport
 const resultsTableHeader = '|File|Errors|Warnings\r|---|---|---|\r'
-const resultsTableRows = lintReport.results.map(file =>
-    `|${file.filePath}|${file.errorCount}|${file.warningCount}|`)
+const resultsTableRows = lintReport.results.map(file => {
+  const travisBasePath = /home\/travis\/build\/\w+\/Spoke\//
+  const localPath = file.filePath.replace(travisBasePath, '')
+  return `|${localPath}|${file.errorCount}|${file.warningCount}|`
+})
 const resultsTable = resultsTableHeader + resultsTableRows.join('\r')
+
 if (errorCount > 0) {
   fail(`Linter: ${errorCount} errors and ${warningCount} warnings.`)
   markdown(resultsTable)
@@ -21,10 +25,3 @@ if (errorCount > 0) {
 } else {
   markdown('This PR passed the linter!')
 }
-
-// const linterOutput = fs.readFileSync('/tmp/eslint.out').toString()
-
-// if (linterOutput.includes('problems')) {
-//   markdown(`These changes failed to pass the linter:
-//     ${linterOutput}`)
-// }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -8,7 +8,7 @@ const lintReport = linter.executeOnFiles([...modified, ...created])
 // console.log(lintReport.results)
 
 const { warningCount, errorCount } = lintReport
-const resultsTableHeader = '|File|Errors|Warnings\r|---|---|---|\r'
+const resultsTableHeader = '### Linter results\r|File|Errors|Warnings\r|---|---|---|\r'
 const resultsTableRows = lintReport.results.map(file => {
   const travisBasePath = /home\/travis\/build\/\w+\/Spoke\//
   const localPath = file.filePath.replace(travisBasePath, '')

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -13,11 +13,11 @@ const resultsTableRows = lintReport.results.map(file =>
     `|${file.filePath}|${file.errorCount}|${file.warningCount}|`)
 const resultsTable = resultsTableHeader + resultsTableRows.join('\r')
 if (errorCount > 0) {
-  fail(`Linter found ${errorCount} errors and ${warningCount} warnings:
-    ${resultsTable}`)
+  fail(`Linter: ${errorCount} errors and ${warningCount} warnings.`)
+  markdown(resultsTable)
 } else if (warningCount > 0) {
-  warn(`Linter found ${warningCount} warnings:
-    ${resultsTable}`)
+  warn(`Linter: ${warningCount} warnings.`)
+  markdown(resultsTable)
 } else {
   markdown('This PR passed the linter!')
 }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,4 @@
+import { message, danger } from 'danger'
+
+const modifiedMD = danger.git.modified_files.join('- ')
+message('Changed Files in this PR: \n - ' + modifiedMD)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,4 +1,13 @@
-import { message, danger } from 'danger'
+import { message, danger, markdown } from 'danger'
+import fs from 'fs'
 
 const modifiedMD = danger.git.modified_files.join('- ')
 message('Changed Files in this PR: \n - ' + modifiedMD)
+
+
+const linterOutput = fs.readFileSync('/tmp/eslint.out').toString()
+
+if (linterOutput.includes('Failed')) {
+  markdown(`These changes failed to pass the linter:
+    ${linterOutput}`)
+}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,13 +1,30 @@
-import { message, danger, markdown } from 'danger'
-import fs from 'fs'
+import { markdown, danger, fail, warn } from 'danger'
+import { CLIEngine } from 'eslint'
+import config from './.eslintrc'
 
-const modifiedMD = danger.git.modified_files.join('- ')
-message('Changed Files in this PR: \n - ' + modifiedMD)
+const { modified_files: modified, created_files: created } = danger.git
+const linter = new CLIEngine(config)
+const lintReport = linter.executeOnFiles([...modified, ...created])
+// console.log(lintReport.results)
 
-
-const linterOutput = fs.readFileSync('/tmp/eslint.out').toString()
-
-if (linterOutput.includes('problems')) {
-  markdown(`These changes failed to pass the linter:
-    ${linterOutput}`)
+const { warningCount, errorCount } = lintReport
+const resultsTableHeader = '|File|Errors|Warnings\r|---|---|---|\r'
+const resultsTableRows = lintReport.results.map(file =>
+    `|${file.filePath}|${file.errorCount}|${file.warningCount}|`)
+const resultsTable = resultsTableHeader + resultsTableRows.join('\r')
+if (errorCount > 0) {
+  fail(`Linter found ${errorCount} errors and ${warningCount} warnings:
+    ${resultsTable}`)
+} else if (warningCount > 0) {
+  warn(`Linter found ${warningCount} warnings:
+    ${resultsTable}`)
+} else {
+  markdown('This PR passed the linter!')
 }
+
+// const linterOutput = fs.readFileSync('/tmp/eslint.out').toString()
+
+// if (linterOutput.includes('problems')) {
+//   markdown(`These changes failed to pass the linter:
+//     ${linterOutput}`)
+// }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -7,7 +7,7 @@ message('Changed Files in this PR: \n - ' + modifiedMD)
 
 const linterOutput = fs.readFileSync('/tmp/eslint.out').toString()
 
-if (linterOutput.includes('Failed')) {
+if (linterOutput.includes('problems')) {
   markdown(`These changes failed to pass the linter:
     ${linterOutput}`)
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test-coverage": "jest --coverage",
     "test-coverage-bothbackends": "jest --runInBand --config jest.config.sqlite.js -- __test__/backend.test.js &&  jest --coverage",
     "clean": "rm -rf $OUTPUT_DIR",
-    "lint": "eslint --fix --ext js --ext jsx src",
+    "lint": "eslint --ext js --ext jsx src",
     "prod-build-client": "webpack --config ./webpack/config.js",
     "prod-build-server": "babel ./src -d ./build/server --source-maps --copy-files",
     "prod-build": "npm run clean && npm run prod-build-client && npm run prod-build-server",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postinstall": "if [ \"$NODE_ENV\" = production ] ; then npm run prod-build && npm run prod-static-upload && npm run notify-slack; fi",
     "notify-slack": "if [ \"$SLACK_NOTIFY_URL\" != \"\" ] ; then echo notifying slack && curl -XPOST -d '{\"channel\": \"#spoke\", \"text\":\"'\"$(whoami) building spoke $(git log -1 --pretty=%h) for $AWS_S3_BUCKET_NAME\"'\"}' $SLACK_NOTIFY_URL; fi",
     "start": "node ./build/server/server",
+    "danger": "danger",
     "dev-message-sender-01": "nodemon -e js,jsx -w ./src --exec ./dev-tools/babel-run -- ./src/workers/message-sender-01",
     "prod-message-sender-01": "./dev-tools/babel-run ./src/workers/message-sender-01.js",
     "dev-message-sender-234": "nodemon -e js,jsx -w ./src --exec ./dev-tools/babel-run -- ./src/workers/message-sender-234",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "babel-jest": "^22.1.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2017": "^6.24.1",
+    "danger": "^7.0.14",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-15": "^1.0.5",
     "eslint": "2.13.1",


### PR DESCRIPTION
This PR enables automatic linting of the files that were changed in any given PR. On success, a message like [this one](https://github.com/harpojaeger/Spoke/pull/7#issuecomment-475071553) is added by a bot:
<img width="784" alt="Screen Shot 2019-03-20 at 20 21 01" src="https://user-images.githubusercontent.com/4314013/54727369-ce774a00-4b4d-11e9-9757-325e30ad7b05.png">
 On failure/warning, it looks like [this](https://github.com/harpojaeger/Spoke/pull/6#issuecomment-474171073):
<img width="787" alt="Screen Shot 2019-03-20 at 20 21 10" src="https://user-images.githubusercontent.com/4314013/54727380-d7681b80-4b4d-11e9-85c2-4dd70451cc89.png">

After this is merged, some trivial Travis CI setup is necessary to complete the process (I'll handle that).

`dangerfile.js` is where the actual linting logic is performed (this can be used for lots of things besides linting). Updates to `.travis.yml` are necessary to actually run Danger as part of CI. It was necessary to make `.eslintrc` into a JSON file so it could be imported and parsed in the Dangerfile. Also, I disabled auto-fixing in the default `npm run lint` script.